### PR TITLE
Router branch

### DIFF
--- a/serverDiagram.uml
+++ b/serverDiagram.uml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Diagram>
+  <ID>JAVA</ID>
+  <OriginalElement />
+  <nodes>
+    <node x="561.25" y="475.0">com.softgroup.common.protocol.ResponseStatus</node>
+    <node x="40.5" y="395.0">com.softgroup.common.exceptions.MapperException</node>
+    <node x="343.0" y="710.0">com.softgroup.common.protocol.ResponseData</node>
+    <node x="516.9444444444445" y="240.0">com.softgroup.authorization.api.router.AuthorizationRouterHandler</node>
+    <node x="232.99999999999997" y="630.0">com.softgroup.common.protocol.Data</node>
+    <node x="137.99999999999997" y="790.0">com.softgroup.authorization.api.message.LoginRequest</node>
+    <node x="0.0" y="790.0">com.softgroup.authorization.api.message.RegisterRequest</node>
+    <node x="0.0" y="160.0">com.softgroup.authorization.api.router.AuthorizationRequestHandler</node>
+    <node x="264.0" y="790.0">com.softgroup.authorization.api.message.RegisterResponse</node>
+    <node x="410.0" y="790.0">com.softgroup.authorization.api.message.LoginResponse</node>
+    <node x="136.1944444444444" y="80.0">com.softgroup.common.router.api.RequestHandler</node>
+    <node x="434.25" y="315.0">com.softgroup.common.protocol.ActionHeader</node>
+    <node x="569.0" y="630.0">com.softgroup.common.datamapper.support.ModelWithEnum</node>
+    <node x="392.0" y="160.0">com.softgroup.common.router.api.CommonRouterHandler</node>
+    <node x="743.0" y="713.0">com.softgroup.common.datamapper.support.ModelB</node>
+    <node x="738.0" y="630.0">com.softgroup.common.datamapper.support.ModelA</node>
+    <node x="210.0" y="160.0">com.softgroup.common.router.api.AbstractRequestHandler</node>
+    <node x="34.5" y="315.0">com.softgroup.common.exceptions.SoftgroupException</node>
+    <node x="584.5" y="710.0">com.softgroup.common.datamapper.support.ModelWithEnum.ModelType</node>
+    <node x="229.0" y="475.0">com.softgroup.common.datamapper.DataMapperAppCfgIT</node>
+    <node x="574.0" y="160.0">com.softgroup.common.router.api.AbstractRouterHandler</node>
+    <node x="69.0" y="475.0">com.softgroup.common.datamapper.JacksonDataMapper</node>
+    <node x="357.8611111111111" y="0.0">com.softgroup.common.router.api.Handler</node>
+    <node x="0.0" y="555.0">com.softgroup.common.datamapper.configuration.DataMapperAppCfg</node>
+    <node x="74.99999999999997" y="710.0">com.softgroup.common.protocol.RequestData</node>
+    <node x="453.25" y="395.0">com.softgroup.common.protocol.Action</node>
+    <node x="434.25" y="475.0">com.softgroup.common.protocol.RoutedAction</node>
+    <node x="556.25" y="555.0">com.softgroup.common.protocol.Response</node>
+    <node x="423.0" y="555.0">com.softgroup.common.protocol.Request</node>
+    <node x="160.0" y="555.0">com.softgroup.common.datamapper.MapperTest</node>
+    <node x="571.3333333333333" y="80.0">com.softgroup.common.router.api.RouterHandler</node>
+    <node x="229.25" y="395.0">com.softgroup.common.datamapper.DataMapper</node>
+  </nodes>
+  <notes />
+  <edges>
+    <edge source="com.softgroup.authorization.api.message.LoginRequest" target="com.softgroup.common.protocol.RequestData">
+      <point x="0.0" y="-15.0" />
+      <point x="190.99999999999997" y="765.0" />
+      <point x="149.99999999999997" y="765.0" />
+      <point x="25.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.protocol.RoutedAction" target="com.softgroup.common.protocol.Action">
+      <point x="0.0" y="-15.0" />
+      <point x="0.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.authorization.api.message.RegisterResponse" target="com.softgroup.common.protocol.ResponseData">
+      <point x="0.0" y="-15.0" />
+      <point x="327.0" y="765.0" />
+      <point x="370.0" y="765.0" />
+      <point x="-27.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.datamapper.JacksonDataMapper" target="com.softgroup.common.datamapper.DataMapper">
+      <point x="35.0" y="-15.0" />
+      <point x="174.0" y="450.0" />
+      <point x="254.0" y="450.0" />
+      <point x="-24.75" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.protocol.Response" target="com.softgroup.common.protocol.RoutedAction">
+      <point x="-21.0" y="-15.0" />
+      <point x="577.25" y="530.0" />
+      <point x="514.5" y="530.0" />
+      <point x="26.75" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.protocol.Request" target="com.softgroup.common.protocol.RoutedAction">
+      <point x="0.0" y="-15.0" />
+      <point x="-26.75" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.router.api.RouterHandler" target="com.softgroup.common.router.api.Handler">
+      <point x="0.0" y="-15.0" />
+      <point x="626.8333333333333" y="55.0" />
+      <point x="414.8611111111111" y="55.0" />
+      <point x="19.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.router.api.AbstractRequestHandler" target="com.softgroup.common.router.api.RequestHandler">
+      <point x="0.0" y="-15.0" />
+      <point x="291.0" y="135.0" />
+      <point x="224.6944444444444" y="135.0" />
+      <point x="29.5" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.datamapper.support.ModelWithEnum.ModelType" target="com.softgroup.common.datamapper.support.ModelWithEnum">
+      <point x="-23.25" y="-15.0" />
+      <point x="607.75" y="685.0" />
+      <point x="600.0" y="685.0" />
+      <point x="-31.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.authorization.api.router.AuthorizationRequestHandler" target="com.softgroup.common.router.api.RequestHandler">
+      <point x="0.0" y="-15.0" />
+      <point x="95.0" y="135.0" />
+      <point x="165.6944444444444" y="135.0" />
+      <point x="-29.5" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.protocol.ResponseData" target="com.softgroup.common.protocol.Data">
+      <point x="0.0" y="-15.0" />
+      <point x="397.0" y="685.0" />
+      <point x="276.5" y="685.0" />
+      <point x="14.5" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.authorization.api.router.AuthorizationRouterHandler" target="com.softgroup.common.router.api.CommonRouterHandler">
+      <point x="-45.75" y="-15.0" />
+      <point x="562.6944444444445" y="215.0" />
+      <point x="473.0" y="215.0" />
+      <point x="0.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.router.api.CommonRouterHandler" target="com.softgroup.common.router.api.RouterHandler">
+      <point x="0.0" y="-15.0" />
+      <point x="473.0" y="135.0" />
+      <point x="589.8333333333333" y="135.0" />
+      <point x="-37.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.router.api.AbstractRouterHandler" target="com.softgroup.common.router.api.RouterHandler">
+      <point x="0.0" y="-15.0" />
+      <point x="651.5" y="135.0" />
+      <point x="626.8333333333333" y="135.0" />
+      <point x="0.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.authorization.api.message.LoginResponse" target="com.softgroup.common.protocol.ResponseData">
+      <point x="0.0" y="-15.0" />
+      <point x="467.0" y="765.0" />
+      <point x="424.0" y="765.0" />
+      <point x="27.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.router.api.RequestHandler" target="com.softgroup.common.router.api.Handler">
+      <point x="0.0" y="-15.0" />
+      <point x="195.1944444444444" y="55.0" />
+      <point x="376.8611111111111" y="55.0" />
+      <point x="-19.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.protocol.RequestData" target="com.softgroup.common.protocol.Data">
+      <point x="0.0" y="-15.0" />
+      <point x="124.99999999999997" y="685.0" />
+      <point x="247.49999999999997" y="685.0" />
+      <point x="-14.5" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.authorization.api.message.RegisterRequest" target="com.softgroup.common.protocol.RequestData">
+      <point x="0.0" y="-15.0" />
+      <point x="59.0" y="765.0" />
+      <point x="99.99999999999997" y="765.0" />
+      <point x="-25.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.common.exceptions.MapperException" target="com.softgroup.common.exceptions.SoftgroupException">
+      <point x="0.0" y="-15.0" />
+      <point x="0.0" y="15.0" />
+    </edge>
+    <edge source="com.softgroup.authorization.api.router.AuthorizationRouterHandler" target="com.softgroup.common.router.api.RouterHandler">
+      <point x="45.75" y="-15.0" />
+      <point x="654.1944444444445" y="215.0" />
+      <point x="739.5" y="215.0" />
+      <point x="739.5" y="135.0" />
+      <point x="663.8333333333333" y="135.0" />
+      <point x="37.0" y="15.0" />
+    </edge>
+  </edges>
+  <settings layout="Hierarchic Group" zoom="1.0" x="374.5" y="405.0" />
+  <SelectedNodes>
+    <node>com.softgroup.common.datamapper.support.ModelB</node>
+  </SelectedNodes>
+  <Categories>
+    <Category>Inner Classes</Category>
+  </Categories>
+  <SCOPE>All</SCOPE>
+  <VISIBILITY>private</VISIBILITY>
+</Diagram>
+

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/Contact.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/Contact.java
@@ -1,0 +1,29 @@
+package com.softgroup.common.protocol.entry;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class Contact {
+    //номера телефонов
+    private ArrayList<String> phone_number;
+    //имя контакта
+    private	String name;
+
+    public ArrayList<String> getPhone_number() {
+        return phone_number;
+    }
+
+    public void setPhone_number(ArrayList<String> phone_number) {
+        this.phone_number = phone_number;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/Conversation.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/Conversation.java
@@ -1,0 +1,57 @@
+package com.softgroup.common.protocol.entry;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class Conversation {
+    //ключ
+    private String id;
+    //имя чата
+    private String name;
+    //Ссылка на логотип чата либо лого по умолчанию
+    private String logo_image_uri;
+    //тип (0-индивидуальный, 1-групповой)
+    private Integer type;
+    //индекс последнего сообщения
+    private Long last_message_index;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLogo_image_uri() {
+        return logo_image_uri;
+    }
+
+    public void setLogo_image_uri(String logo_image_uri) {
+        this.logo_image_uri = logo_image_uri;
+    }
+
+    public Integer getType() {
+        return type;
+    }
+
+    public void setType(Integer type) {
+        this.type = type;
+    }
+
+    public Long getLast_message_index() {
+        return last_message_index;
+    }
+
+    public void setLast_message_index(Long last_message_index) {
+        this.last_message_index = last_message_index;
+    }
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/ConversationDetails.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/ConversationDetails.java
@@ -1,0 +1,29 @@
+package com.softgroup.common.protocol.entry;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ConversationDetails {
+    // Conversation
+    private String id ;
+    //список учасников
+    private ArrayList<Profile> members;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public ArrayList<Profile> getMembers() {
+        return members;
+    }
+
+    public void setMembers(ArrayList<Profile> members) {
+        this.members = members;
+    }
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/ConversationSettings.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/ConversationSettings.java
@@ -1,0 +1,50 @@
+package com.softgroup.common.protocol.entry;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ConversationSettings {
+    //Conversation
+    private String id;
+    //id администратора группы
+    private String admin_id;
+    //название группы
+    private String name;
+    //логотип группы назначеный админом
+    private String logo_image_uri;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getAdmin_id() {
+        return admin_id;
+    }
+
+    public void setAdmin_id(String admin_id) {
+        this.admin_id = admin_id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLogo_image_uri() {
+        return logo_image_uri;
+    }
+
+    public void setLogo_image_uri(String logo_image_uri) {
+        this.logo_image_uri = logo_image_uri;
+    }
+
+
+
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/CursorRequest.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/CursorRequest.java
@@ -1,0 +1,27 @@
+package com.softgroup.common.protocol.entry;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class CursorRequest {
+    //колличество
+    private	Integer	count;
+    //количество в выборке
+    private	Integer	offset;
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    public Integer getOffset() {
+        return offset;
+    }
+
+    public void setOffset(Integer offset) {
+        this.offset = offset;
+    }
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/CursorResponse.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/CursorResponse.java
@@ -1,0 +1,17 @@
+package com.softgroup.common.protocol.entry;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class CursorResponse {
+    //наличие данных ещё
+    private	Boolean	is_more_exists;
+
+    public Boolean getIs_more_exists() {
+        return is_more_exists;
+    }
+
+    public void setIs_more_exists(Boolean is_more_exists) {
+        this.is_more_exists = is_more_exists;
+    }
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/DTO/ConversationFullDTO.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/DTO/ConversationFullDTO.java
@@ -1,0 +1,107 @@
+package com.softgroup.common.protocol.entry.DTO;
+
+import com.softgroup.common.protocol.entry.Message;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ConversationFullDTO {
+
+    //id конверсейшна
+    private String id;
+    //Сообщения
+    private ArrayList<Message> messages;
+    //Количество непрочитанных
+    private Long	total_unread;
+    //Существует ли конверсейшн
+    private Boolean	exists;
+    //Имя
+    private String name;
+    //Ссылка на логотип чата
+    private String	logo_image_uri;
+    //тип (0-индивидуальный, 1-групповой)
+    private Integer	type;
+    //индекс последнего сообщения
+    private Long	last_message_index;
+    //список ИД пользователей
+    private ArrayList<String> members_ids;
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public ArrayList<Message> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(ArrayList<Message> messages) {
+        this.messages = messages;
+    }
+
+    public Long getTotal_unread() {
+        return total_unread;
+    }
+
+    public void setTotal_unread(Long total_unread) {
+        this.total_unread = total_unread;
+    }
+
+    public Boolean getExists() {
+        return exists;
+    }
+
+    public void setExists(Boolean exists) {
+        this.exists = exists;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLogo_image_uri() {
+        return logo_image_uri;
+    }
+
+    public void setLogo_image_uri(String logo_image_uri) {
+        this.logo_image_uri = logo_image_uri;
+    }
+
+    public Integer getType() {
+        return type;
+    }
+
+    public void setType(Integer type) {
+        this.type = type;
+    }
+
+    public Long getLast_message_index() {
+        return last_message_index;
+    }
+
+    public void setLast_message_index(Long last_message_index) {
+        this.last_message_index = last_message_index;
+    }
+
+    public ArrayList<String> getMembers_ids() {
+        return members_ids;
+    }
+
+    public void setMembers_ids(ArrayList<String> members_ids) {
+        this.members_ids = members_ids;
+    }
+
+
+
+
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/DTO/ConversationSyncDTO.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/DTO/ConversationSyncDTO.java
@@ -1,0 +1,28 @@
+package com.softgroup.common.protocol.entry.DTO;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ConversationSyncDTO {
+    //id конверсейшна
+    private String	id;
+    //индекс последнего сообщения на клиенте
+    private String	last_message_index;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getLast_message_index() {
+        return last_message_index;
+    }
+
+    public void setLast_message_index(String last_message_index) {
+        this.last_message_index = last_message_index;
+    }
+
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/DTO/MessageRequestDTO.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/DTO/MessageRequestDTO.java
@@ -1,0 +1,47 @@
+package com.softgroup.common.protocol.entry.DTO;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class MessageRequestDTO {
+    //id Conversation
+    private	String conversation_id;
+    //Тип сообщения
+    private	Integer message_type;
+    //текст сообщения
+    private	String payload;
+    //создание на клиенте
+    private	Long create_time;
+
+    public String getConversation_id() {
+        return conversation_id;
+    }
+
+    public void setConversation_id(String conversation_id) {
+        this.conversation_id = conversation_id;
+    }
+
+    public Integer getMessage_type() {
+        return message_type;
+    }
+
+    public void setMessage_type(Integer message_type) {
+        this.message_type = message_type;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public Long getCreate_time() {
+        return create_time;
+    }
+
+    public void setCreate_time(Long create_time) {
+        this.create_time = create_time;
+    }
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/DTO/ProfileSyncDTO.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/DTO/ProfileSyncDTO.java
@@ -1,0 +1,27 @@
+package com.softgroup.common.protocol.entry.DTO;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ProfileSyncDTO {
+    //ключ
+    private	String	id;
+    //дата изменения
+    private	Long	last_modified;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Long getLast_modified() {
+        return last_modified;
+    }
+
+    public void setLast_modified(Long last_modified) {
+        this.last_modified = last_modified;
+    }
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/Message.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/Message.java
@@ -1,0 +1,97 @@
+package com.softgroup.common.protocol.entry;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class Message {
+    //ключ
+    private String id;
+    //id отправителя
+    private String sender_id;
+    //id Conversation
+    private String conversation_id;
+    //Тип сообщения
+    private Integer message_type;
+    //текст сообщения
+    private String payload;
+    //состояние (выдаётся сервером)
+    private Integer status;
+    //создание на клиенте
+    private Long create_time;
+    //время получения сервером
+    private Long server_receive_time;
+    //индекс сообщения
+    private Long message_index;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getSender_id() {
+        return sender_id;
+    }
+
+    public void setSender_id(String sender_id) {
+        this.sender_id = sender_id;
+    }
+
+    public String getConversation_id() {
+        return conversation_id;
+    }
+
+    public void setConversation_id(String conversation_id) {
+        this.conversation_id = conversation_id;
+    }
+
+    public Integer getMessage_type() {
+        return message_type;
+    }
+
+    public void setMessage_type(Integer message_type) {
+        this.message_type = message_type;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public Long getCreate_time() {
+        return create_time;
+    }
+
+    public void setCreate_time(Long create_time) {
+        this.create_time = create_time;
+    }
+
+    public Long getServer_receive_time() {
+        return server_receive_time;
+    }
+
+    public void setServer_receive_time(Long server_receive_time) {
+        this.server_receive_time = server_receive_time;
+    }
+
+    public Long getMessage_index() {
+        return message_index;
+    }
+
+    public void setMessage_index(Long message_index) {
+        this.message_index = message_index;
+    }
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/Profile.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/Profile.java
@@ -1,0 +1,77 @@
+package com.softgroup.common.protocol.entry;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class Profile {
+    //ключ
+    private	String	id;
+    //полный номер телефона
+    private	String	phone_number;
+    //дата регистрации
+    private	Long	create_date_time;
+    //дата изменения
+    private	Long	update_date_time;
+    //ссылка на аватар пользователя
+    private	String	avatar_uri;
+    //имя пользователя
+    private	String	name;
+    ///я на море
+    private	String	status;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getPhone_number() {
+        return phone_number;
+    }
+
+    public void setPhone_number(String phone_number) {
+        this.phone_number = phone_number;
+    }
+
+    public Long getCreate_date_time() {
+        return create_date_time;
+    }
+
+    public void setCreate_date_time(Long create_date_time) {
+        this.create_date_time = create_date_time;
+    }
+
+    public Long getUpdate_date_time() {
+        return update_date_time;
+    }
+
+    public void setUpdate_date_time(Long update_date_time) {
+        this.update_date_time = update_date_time;
+    }
+
+    public String getAvatar_uri() {
+        return avatar_uri;
+    }
+
+    public void setAvatar_uri(String avatar_uri) {
+        this.avatar_uri = avatar_uri;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/ProfileSettings.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/ProfileSettings.java
@@ -1,0 +1,8 @@
+package com.softgroup.common.protocol.entry;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ProfileSettings {
+
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/ProfileStatus.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/ProfileStatus.java
@@ -1,0 +1,37 @@
+package com.softgroup.common.protocol.entry;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ProfileStatus {
+    //ключ <Profile>
+    private	String id;
+    //Или в онлайне
+    private	Boolean is_online;
+    //Последний раз в онлайне
+    private	Long last_time_online;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Boolean getIs_online() {
+        return is_online;
+    }
+
+    public void setIs_online(Boolean is_online) {
+        this.is_online = is_online;
+    }
+
+    public Long getLast_time_online() {
+        return last_time_online;
+    }
+
+    public void setLast_time_online(Long last_time_online) {
+        this.last_time_online = last_time_online;
+    }
+}

--- a/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/ProfileStrict.java
+++ b/softgroup/basis/common-protocol/src/main/java/com/softgroup/common/protocol/entry/ProfileStrict.java
@@ -1,0 +1,37 @@
+package com.softgroup.common.protocol.entry;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ProfileStrict {
+    //ключ
+    private	String	id;
+    //полный номер телефона
+    private	String	phone_number;
+    //имя пользователя
+    private	String	name;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getPhone_number() {
+        return phone_number;
+    }
+
+    public void setPhone_number(String phone_number) {
+        this.phone_number = phone_number;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/AbstractCommandRouterHandler.java
+++ b/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/AbstractCommandRouterHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.common.router.api;
+
+import com.softgroup.common.protocol.Request;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public abstract class AbstractCommandRouterHandler<T extends Handler> extends AbstractRouterHandler<T>{
+
+    @Override
+    public abstract String getName();
+
+    @Override
+    public String getRouteKey(Request<?> msg) {
+        return msg.getHeader().getCommand();
+    }
+}

--- a/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/AbstractRequestHandler.java
+++ b/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/AbstractRequestHandler.java
@@ -6,7 +6,7 @@ import com.softgroup.common.protocol.RequestData;
 import com.softgroup.common.protocol.Response;
 import com.softgroup.common.protocol.ResponseData;
 
-public class AbstractRequestHandler<T extends RequestData, R extends ResponseData> implements RequestHandler {
+public abstract class AbstractRequestHandler<T extends RequestData, R extends ResponseData> implements RequestHandler {
 	@Override
 	public String getName() {
 		return null;

--- a/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/AbstractRouterHandler.java
+++ b/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/AbstractRouterHandler.java
@@ -1,18 +1,47 @@
 package com.softgroup.common.router.api;
 
+import com.softgroup.common.protocol.ActionHeader;
 import com.softgroup.common.protocol.Request;
 import com.softgroup.common.protocol.Response;
+import com.softgroup.common.protocol.ResponseStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public abstract class AbstractRouterHandler<T extends Handler> implements RouterHandler {
 
+	@Autowired
+	private List<T> handlers;
+	private Map<String,T> handlerMap = new HashMap<String, T>();
+
+	public abstract String getName();
+
 	@Override
-	public String getRouteKey(Request<?> msg) {
-		return null;
-	}
+	public abstract String getRouteKey(Request<?> msg) ;
 
 	@Override
 	public Response<?> handle(Request<?> msg) {
-		return null;
+		if(handlerMap.containsKey(getRouteKey(msg))) {
+			T handler = handlerMap.get(getRouteKey(msg));
+			return handler.handle(msg);
+		}else{
+			Response badResponse = new Response();
+			badResponse.setStatus(new ResponseStatus());
+			badResponse.getStatus().setCode(422);
+			badResponse.getStatus().setMessage("Bad request or not implemented");
+			return badResponse;
+		}
+
 	}
 
+
+	@PostConstruct
+	public void init () {
+		for (T handler:handlers) {
+			handlerMap.put(handler.getName(),handler);
+		}
+	}
 }

--- a/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/AbstractTypeRouterHandler.java
+++ b/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/AbstractTypeRouterHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.common.router.api;
+
+import com.softgroup.common.protocol.Request;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public abstract class AbstractTypeRouterHandler<T extends Handler> extends AbstractRouterHandler<T>{
+
+    @Override
+    public abstract String getName();
+
+    @Override
+    public String getRouteKey(Request<?> msg) {
+        return msg.getHeader().getCommand();
+    }
+}

--- a/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/CommandTypeRouter.java
+++ b/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/CommandTypeRouter.java
@@ -1,0 +1,10 @@
+package com.softgroup.common.router.api;
+
+import com.softgroup.common.router.api.CommonRouterHandler;
+import com.softgroup.common.router.api.RouterHandler;
+
+/**
+ * Created by user on 27.02.2017.
+ */
+public interface CommandTypeRouter extends RouterHandler, CommonRouterHandler {
+}

--- a/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/Handler.java
+++ b/softgroup/basis/common-router/src/main/java/com/softgroup/common/router/api/Handler.java
@@ -3,7 +3,7 @@ package com.softgroup.common.router.api;
 import com.softgroup.common.protocol.Request;
 import com.softgroup.common.protocol.Response;
 
-public interface Handler {
+public interface Handler  {
     String getName();
 
     Response<?> handle(final Request<?> msg);

--- a/softgroup/services/authorization/authorization-api/src/main/java/com/softgroup/authorization/api/message/RegisterRequest.java
+++ b/softgroup/services/authorization/authorization-api/src/main/java/com/softgroup/authorization/api/message/RegisterRequest.java
@@ -8,4 +8,32 @@ import com.softgroup.common.protocol.RequestData;
  */
 public class RegisterRequest implements RequestData{
 	private static final long serialVersionUID = -645554380912935546L;
+
+	private String phoneNumber;
+	private String localeCode;
+	private String deviceId;
+
+	public String getPhoneNumber() {
+		return phoneNumber;
+	}
+
+	public void setPhoneNumber(String phoneNumber) {
+		this.phoneNumber = phoneNumber;
+	}
+
+	public String getLocaleCode() {
+		return localeCode;
+	}
+
+	public void setLocaleCode(String localeCode) {
+		this.localeCode = localeCode;
+	}
+
+	public String getDeviceId() {
+		return deviceId;
+	}
+
+	public void setDeviceId(String deviceId) {
+		this.deviceId = deviceId;
+	}
 }

--- a/softgroup/services/authorization/authorization-api/src/main/java/com/softgroup/authorization/api/message/RegisterResponse.java
+++ b/softgroup/services/authorization/authorization-api/src/main/java/com/softgroup/authorization/api/message/RegisterResponse.java
@@ -8,4 +8,32 @@ import com.softgroup.common.protocol.ResponseData;
  */
 public class RegisterResponse implements ResponseData {
 	private static final long serialVersionUID = -5146888202653750948L;
+
+	private String registrationRequestUuid;
+	private String registrationTimeoutSec;
+	private String authCode;
+
+	public String getRegistrationRequestUuid() {
+		return registrationRequestUuid;
+	}
+
+	public void setRegistrationRequestUuid(String registrationRequestUuid) {
+		this.registrationRequestUuid = registrationRequestUuid;
+	}
+
+	public String getRegistrationTimeoutSec() {
+		return registrationTimeoutSec;
+	}
+
+	public void setRegistrationTimeoutSec(String registrationTimeoutSec) {
+		this.registrationTimeoutSec = registrationTimeoutSec;
+	}
+
+	public String getAuthCode() {
+		return authCode;
+	}
+
+	public void setAuthCode(String authCode) {
+		this.authCode = authCode;
+	}
 }

--- a/softgroup/services/authorization/authorization-api/src/main/java/com/softgroup/authorization/api/message/SmsConfirmRequest.java
+++ b/softgroup/services/authorization/authorization-api/src/main/java/com/softgroup/authorization/api/message/SmsConfirmRequest.java
@@ -1,0 +1,31 @@
+package com.softgroup.authorization.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+/**
+ * Created by user on 25.02.2017.
+ */
+public class SmsConfirmRequest implements RequestData {
+
+    private static final long serialVersionUID = 895237867750981751L;
+
+    private String authCode;
+    private String registrationRequestUuid;
+
+    public String getAuthCode() {
+        return authCode;
+    }
+
+    public void setAuthCode(String authCode) {
+        this.authCode = authCode;
+    }
+
+    public String getRegistrationRequestUuid() {
+        return registrationRequestUuid;
+    }
+
+    public void setRegistrationRequestUuid(String registrationRequestUuid) {
+        this.registrationRequestUuid = registrationRequestUuid;
+    }
+}
+

--- a/softgroup/services/authorization/authorization-api/src/main/java/com/softgroup/authorization/api/message/SmsConfirmResponse.java
+++ b/softgroup/services/authorization/authorization-api/src/main/java/com/softgroup/authorization/api/message/SmsConfirmResponse.java
@@ -1,0 +1,20 @@
+package com.softgroup.authorization.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+
+/**
+ * Created by user on 25.02.2017.
+ */
+public class SmsConfirmResponse implements ResponseData {
+    private static final long serialVersionUID = 8952378677509681751L;
+
+    private String deviceToken;
+
+    public String getDeviceToken() {
+        return deviceToken;
+    }
+
+    public void setDeviceToken(String deviceToken) {
+        this.deviceToken = deviceToken;
+    }
+}

--- a/softgroup/services/authorization/authorization-impl/pom.xml
+++ b/softgroup/services/authorization/authorization-impl/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>authorization</artifactId>
+		<groupId>com.softgroup</groupId>
+		<version>0.0.1</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>authorization-impl</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.softgroup</groupId>
+			<artifactId>authorization-api</artifactId>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/softgroup/services/authorization/authorization-impl/src/main/java/com/softgroup/authorithation/impl/handler/LoginRequestHandler.java
+++ b/softgroup/services/authorization/authorization-impl/src/main/java/com/softgroup/authorithation/impl/handler/LoginRequestHandler.java
@@ -1,0 +1,25 @@
+package com.softgroup.authorithation.impl.handler;
+
+import com.softgroup.authorization.api.message.LoginRequest;
+import com.softgroup.authorization.api.message.LoginResponse;
+import com.softgroup.authorization.api.router.AuthorizationRequestHandler;
+import com.softgroup.common.protocol.*;
+import com.softgroup.common.router.api.AbstractRequestHandler;
+
+/**
+ * Created by user on 24.02.2017.
+ */
+public class LoginRequestHandler extends AbstractRequestHandler<LoginRequest,LoginResponse>  implements AuthorizationRequestHandler{
+
+    public String getName(){
+        return "login";
+    }
+
+    @Override
+    public Response<LoginResponse> handle(Request<?> msg) {
+        Response<LoginResponse> response = new Response<LoginResponse>();
+        response.setData(new LoginResponse());
+        return response;
+    }
+
+}

--- a/softgroup/services/authorization/authorization-impl/src/main/java/com/softgroup/authorithation/impl/handler/RegisterRequestHandler.java
+++ b/softgroup/services/authorization/authorization-impl/src/main/java/com/softgroup/authorithation/impl/handler/RegisterRequestHandler.java
@@ -1,0 +1,26 @@
+package com.softgroup.authorithation.impl.handler;
+
+import com.softgroup.authorization.api.message.RegisterRequest;
+import com.softgroup.authorization.api.message.RegisterResponse;
+import com.softgroup.authorization.api.router.AuthorizationRequestHandler;
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.common.router.api.AbstractRequestHandler;
+
+/**
+ * Created by user on 24.02.2017.
+ */
+public class RegisterRequestHandler extends AbstractRequestHandler<RegisterRequest,RegisterResponse> implements AuthorizationRequestHandler {
+
+    public String getName(){
+        return "register";
+    }
+
+    @Override
+    public Response<RegisterResponse> handle(Request<?> msg) {
+        Response<RegisterResponse> response = new Response<RegisterResponse>();
+        response.setData(new RegisterResponse());
+        return response;
+    }
+
+}

--- a/softgroup/services/authorization/authorization-impl/src/main/java/com/softgroup/authorithation/impl/handler/SmsConfirmRequestHandler.java
+++ b/softgroup/services/authorization/authorization-impl/src/main/java/com/softgroup/authorithation/impl/handler/SmsConfirmRequestHandler.java
@@ -1,0 +1,29 @@
+package com.softgroup.authorithation.impl.handler;
+
+import com.softgroup.authorization.api.message.LoginResponse;
+import com.softgroup.authorization.api.message.SmsConfirmRequest;
+import com.softgroup.authorization.api.message.SmsConfirmResponse;
+import com.softgroup.authorization.api.router.AuthorizationRequestHandler;
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.common.router.api.AbstractRequestHandler;
+
+/**
+ * Created by user on 25.02.2017.
+ */
+
+    public class SmsConfirmRequestHandler extends AbstractRequestHandler<SmsConfirmRequest,SmsConfirmResponse> implements AuthorizationRequestHandler {
+
+    public String getName(){
+            return "sms_confirm";
+        }
+
+    @Override
+    public Response<SmsConfirmResponse> handle(Request<?> msg) {
+        Response<SmsConfirmResponse> response = new Response<SmsConfirmResponse>();
+        response.setData(new SmsConfirmResponse());
+        return response;
+    }
+
+    }
+

--- a/softgroup/services/authorization/authorization-impl/src/main/java/com/softgroup/authorithation/impl/router/AuthorizationRouter.java
+++ b/softgroup/services/authorization/authorization-impl/src/main/java/com/softgroup/authorithation/impl/router/AuthorizationRouter.java
@@ -1,0 +1,21 @@
+package com.softgroup.authorithation.impl.router;
+
+import com.softgroup.authorization.api.router.AuthorizationRequestHandler;
+import com.softgroup.common.router.api.AbstractCommandRouterHandler;
+import com.softgroup.common.router.api.CommandTypeRouter;
+import com.softgroup.common.router.api.CommonRouterHandler;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * Created by user on 24.02.2017.
+ */
+@Component
+public class AuthorizationRouter extends AbstractCommandRouterHandler<AuthorizationRequestHandler> implements CommandTypeRouter {
+
+    @Override
+    public String getName(){
+        return "authorization";
+    }
+
+}

--- a/softgroup/services/authorization/authorization-impl/src/main/java/com/softgroup/authorithation/impl/router/AuthorizationRouterBean.java
+++ b/softgroup/services/authorization/authorization-impl/src/main/java/com/softgroup/authorithation/impl/router/AuthorizationRouterBean.java
@@ -1,0 +1,16 @@
+package com.softgroup.authorithation.impl.router;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+@Configuration
+public class AuthorizationRouterBean {
+
+    @Bean
+    public AuthorizationRouter authorizationRouter(){
+        return new AuthorizationRouter();
+    }
+}

--- a/softgroup/services/authorization/authorization-impl/src/test/java/com/softgroup/authorization/impl/router/AuthorizationRouterTest.java
+++ b/softgroup/services/authorization/authorization-impl/src/test/java/com/softgroup/authorization/impl/router/AuthorizationRouterTest.java
@@ -1,0 +1,116 @@
+package com.softgroup.authorization.impl.router;
+
+import com.softgroup.authorithation.impl.handler.LoginRequestHandler;
+import com.softgroup.authorithation.impl.handler.RegisterRequestHandler;
+import com.softgroup.authorithation.impl.handler.SmsConfirmRequestHandler;
+import com.softgroup.authorithation.impl.router.AuthorizationRouter;
+import com.softgroup.authorithation.impl.router.AuthorizationRouterBean;
+import com.softgroup.authorization.api.message.*;
+import com.softgroup.common.protocol.ActionHeader;
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+import static org.junit.Assert.assertThat;
+/**
+ * Created by user on 26.02.2017.
+ */
+@DirtiesContext
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {AuthorizationRouterBean.class, LoginRequestHandler.class, RegisterRequestHandler.class, SmsConfirmRequestHandler.class})
+public class AuthorizationRouterTest {
+
+    @Autowired
+    AuthorizationRouter router;
+
+    @Test
+    public void isRouterExist(){
+        assertThat(router, CoreMatchers.notNullValue());
+    }
+
+    private Request<LoginRequest> loginRequestREST;
+    private Request<RegisterRequest> registerRequestREST;
+    private Request<SmsConfirmRequest> smsConfirmRequestREST;
+    private Request badRequestREST;
+
+    @Before
+    public void createRequests(){
+        loginRequestREST = new Request<LoginRequest>();
+        ActionHeader header = new ActionHeader();
+        header.setCommand("login");
+        header.setType("authorization");
+        header.setVersion("0");
+        header.setUuid("0000");
+        LoginRequest loginEntry = new LoginRequest();
+        loginEntry.setDeviceToken("de:ee:ad:be:ee:ef");
+        loginRequestREST.setHeader(header);
+        loginRequestREST.setData(loginEntry);
+
+        registerRequestREST = new Request<RegisterRequest>();
+        ActionHeader header1 = new ActionHeader();
+        header1.setCommand("register");
+        header1.setType("authorization");
+        header1.setVersion("0");
+        header1.setUuid("0000");
+        RegisterRequest registerEntry = new RegisterRequest();
+        registerRequestREST.setHeader(header1);
+        registerRequestREST.setData(registerEntry);
+
+        smsConfirmRequestREST = new Request<SmsConfirmRequest>();
+        ActionHeader header2 = new ActionHeader();
+        header2.setCommand("sms_confirm");
+        header2.setType("authorization");
+        header2.setVersion("0");
+        header2.setUuid("0000");
+        SmsConfirmRequest smsConfirmEntry = new SmsConfirmRequest();
+        smsConfirmRequestREST.setHeader(header2);
+        smsConfirmRequestREST.setData(smsConfirmEntry);
+
+        badRequestREST = new Request();
+        ActionHeader header3 = new ActionHeader();
+        header3.setCommand("sms_conform");
+        header3.setType("auth");
+        header3.setVersion("0");
+        header3.setUuid("0000");
+        badRequestREST.setHeader(header3);
+
+    }
+
+    @Test
+    public void traceRouteToLogin(){
+        Response r = router.handle(loginRequestREST);
+        assertThat(r.getData(),is(instanceOf(LoginResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToRegister(){
+        Response r = router.handle(registerRequestREST);
+        assertThat(r.getData(),is(instanceOf(RegisterResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToSmsConfirm(){
+        Response r = router.handle(smsConfirmRequestREST);
+        assertThat(r.getData(),is(instanceOf(SmsConfirmResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToErrorHandler(){
+        Response r = router.handle(badRequestREST);
+        assertThat(r.getStatus().getCode(),is(422));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+}

--- a/softgroup/services/authorization/pom.xml
+++ b/softgroup/services/authorization/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>pom</packaging>
 	<modules>
 		<module>authorization-api</module>
-		<module>authorization-imp</module>
+		<module>authorization-impl</module>
 	</modules>
 
 	<dependencyManagement>

--- a/softgroup/services/common/common-impl/pom.xml
+++ b/softgroup/services/common/common-impl/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>common</artifactId>
+        <groupId>com.softgroup</groupId>
+        <version>0.0.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>common-impl</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>authorization-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>messenger-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>profile-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>authorization-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>messenger-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>profile-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/softgroup/services/common/common-impl/src/main/java/com/softgroup/common/impl/router/CommonTypeRouter.java
+++ b/softgroup/services/common/common-impl/src/main/java/com/softgroup/common/impl/router/CommonTypeRouter.java
@@ -1,0 +1,18 @@
+package com.softgroup.common.impl.router;
+
+import com.softgroup.common.router.api.AbstractCommandRouterHandler;
+import com.softgroup.common.router.api.AbstractTypeRouterHandler;
+import com.softgroup.common.router.api.CommandTypeRouter;
+import com.softgroup.common.router.api.CommonRouterHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+@Component
+public class CommonTypeRouter extends AbstractTypeRouterHandler<CommandTypeRouter>  {
+    @Override
+    public String getName(){
+        return "common";
+    }
+}

--- a/softgroup/services/common/common-impl/src/main/java/com/softgroup/common/impl/router/CommonTypeRouterBean.java
+++ b/softgroup/services/common/common-impl/src/main/java/com/softgroup/common/impl/router/CommonTypeRouterBean.java
@@ -1,0 +1,18 @@
+package com.softgroup.common.impl.router;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Created by user on 27.02.2017.
+ */
+
+@Configuration
+public class CommonTypeRouterBean {
+
+    @Bean
+    public CommonTypeRouter authorizationRouter(){
+        return new CommonTypeRouter();
+    }
+}
+

--- a/softgroup/services/common/common-impl/src/test/java/com/softgroup/common/impl/router/CommonTypeRouterTest.java
+++ b/softgroup/services/common/common-impl/src/test/java/com/softgroup/common/impl/router/CommonTypeRouterTest.java
@@ -1,0 +1,253 @@
+package com.softgroup.common.impl.router;
+
+import com.softgroup.authorithation.impl.handler.LoginRequestHandler;
+import com.softgroup.authorithation.impl.handler.RegisterRequestHandler;
+import com.softgroup.authorithation.impl.handler.SmsConfirmRequestHandler;
+import com.softgroup.authorithation.impl.router.AuthorizationRouter;
+import com.softgroup.authorithation.impl.router.AuthorizationRouterBean;
+import com.softgroup.authorization.api.message.*;
+import com.softgroup.common.protocol.ActionHeader;
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.messenger.api.message.*;
+import com.softgroup.messenger.impl.handler.CreateConversationRequestHandler;
+import com.softgroup.messenger.impl.handler.DeleteConversationRequestHandler;
+import com.softgroup.messenger.impl.handler.GetConversationsByIdsRequestHandler;
+import com.softgroup.messenger.impl.router.MessengerRouter;
+import com.softgroup.messenger.impl.router.MessengerRouterBean;
+import com.softgroup.profile.api.message.*;
+import com.softgroup.profile.impl.handler.ContactsSyncRequestHandler;
+import com.softgroup.profile.impl.handler.GetContactProfilesRequestHandler;
+import com.softgroup.profile.impl.handler.GetLastTimeOnlineRequestHandler;
+import com.softgroup.profile.impl.router.ProfileRouter;
+import com.softgroup.profile.impl.router.ProfileRouterBean;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by user on 27.02.2017.
+ */
+@DirtiesContext
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {CommonTypeRouterBean.class,
+        AuthorizationRouter.class,
+        MessengerRouter.class,
+        ProfileRouter.class,
+        LoginRequestHandler.class,
+        RegisterRequestHandler.class,
+        SmsConfirmRequestHandler.class,
+        CreateConversationRequestHandler.class,
+        DeleteConversationRequestHandler.class,
+        GetConversationsByIdsRequestHandler.class,
+        ContactsSyncRequestHandler.class,
+        GetContactProfilesRequestHandler.class,
+        GetLastTimeOnlineRequestHandler.class
+})
+
+public class CommonTypeRouterTest {
+
+    @Autowired
+    CommonTypeRouter router;
+
+    @Test
+    public void isRouterExist(){
+        assertThat(router, CoreMatchers.notNullValue());
+    }
+
+    private Request<LoginRequest> loginRequestREST;
+    private Request<RegisterRequest> registerRequestREST;
+    private Request<SmsConfirmRequest> smsConfirmRequestREST;
+
+    private Request<ContactsSyncRequest> contactsSyncRequestREST;
+    private Request<GetContactProfilesRequest> getContactProfilesRequestREST;
+    private Request<GetLastTimeOnlineRequest> getLastTimeOnlineRequestREST;
+
+    private Request<CreateConversationRequest> createConversationRequestREST;
+    private Request<DeleteConversationRequest> deleteConversationRequestREST;
+    private Request<GetConversationsByIdsRequest> getConversationsByIdsRequestREST;
+
+    private Request badRequestREST;
+
+    @Before
+    public void createRequests(){
+        loginRequestREST = new Request<LoginRequest>();
+        ActionHeader header = new ActionHeader();
+        header.setCommand("login");
+        header.setType("authorization");
+        header.setVersion("0");
+        header.setUuid("0000");
+        LoginRequest loginEntry = new LoginRequest();
+        loginEntry.setDeviceToken("de:ee:ad:be:ee:ef");
+        loginRequestREST.setHeader(header);
+        loginRequestREST.setData(loginEntry);
+
+        registerRequestREST = new Request<RegisterRequest>();
+        ActionHeader header1 = new ActionHeader();
+        header1.setCommand("register");
+        header1.setType("authorization");
+        header1.setVersion("0");
+        header1.setUuid("0000");
+        RegisterRequest registerEntry = new RegisterRequest();
+        registerRequestREST.setHeader(header1);
+        registerRequestREST.setData(registerEntry);
+
+        smsConfirmRequestREST = new Request<SmsConfirmRequest>();
+        ActionHeader header2 = new ActionHeader();
+        header2.setCommand("sms_confirm");
+        header2.setType("authorization");
+        header2.setVersion("0");
+        header2.setUuid("0000");
+        SmsConfirmRequest smsConfirmEntry = new SmsConfirmRequest();
+        smsConfirmRequestREST.setHeader(header2);
+        smsConfirmRequestREST.setData(smsConfirmEntry);
+
+        badRequestREST = new Request();
+        ActionHeader header3 = new ActionHeader();
+        header3.setCommand("sms_conform");
+        header3.setType("auth");
+        header3.setVersion("0");
+        header3.setUuid("0000");
+        badRequestREST.setHeader(header3);
+
+        contactsSyncRequestREST = new Request<ContactsSyncRequest>();
+        ActionHeader header4 = new ActionHeader();
+        header4.setCommand("contacts_sync");
+        header4.setType("profile");
+        header4.setVersion("0");
+        header4.setUuid("0000");
+        ContactsSyncRequest contactsSyncEntry = new ContactsSyncRequest();
+        contactsSyncRequestREST.setHeader(header4);
+        contactsSyncRequestREST.setData(contactsSyncEntry);
+
+        getContactProfilesRequestREST = new Request<GetContactProfilesRequest>();
+        ActionHeader header5 = new ActionHeader();
+        header5.setCommand("get_contact_profiles");
+        header5.setType("profile");
+        header5.setVersion("0");
+        header5.setUuid("0000");
+        GetContactProfilesRequest getContactProfilesEntry = new GetContactProfilesRequest();
+        getContactProfilesRequestREST.setHeader(header5);
+        getContactProfilesRequestREST.setData(getContactProfilesEntry);
+
+        getLastTimeOnlineRequestREST = new Request<GetLastTimeOnlineRequest>();
+        ActionHeader header6 = new ActionHeader();
+        header6.setCommand("get_last_time_online");
+        header6.setType("profile");
+        header6.setVersion("0");
+        header6.setUuid("0000");
+        GetLastTimeOnlineRequest lastTimeoOnLineEntry = new GetLastTimeOnlineRequest();
+        getLastTimeOnlineRequestREST.setHeader(header6);
+        getLastTimeOnlineRequestREST.setData(lastTimeoOnLineEntry);
+
+        createConversationRequestREST = new Request<CreateConversationRequest>();
+        ActionHeader header7 = new ActionHeader();
+        header7.setCommand("create_conversation");
+        header7.setType("messenger");
+        header7.setVersion("0");
+        header7.setUuid("0000");
+        CreateConversationRequest createConversationEntry = new CreateConversationRequest();
+        createConversationRequestREST.setHeader(header7);
+        createConversationRequestREST.setData(createConversationEntry);
+
+        deleteConversationRequestREST = new Request<DeleteConversationRequest>();
+        ActionHeader header8 = new ActionHeader();
+        header8.setCommand("delete_conversation");
+        header8.setType("messenger");
+        header8.setVersion("0");
+        header8.setUuid("0000");
+        DeleteConversationRequest deleteConversationEntry = new DeleteConversationRequest();
+        deleteConversationRequestREST.setHeader(header8);
+        deleteConversationRequestREST.setData(deleteConversationEntry);
+
+        getConversationsByIdsRequestREST = new Request<GetConversationsByIdsRequest>();
+        ActionHeader header9 = new ActionHeader();
+        header9.setCommand("get_conversations_by_ids");
+        header9.setType("messenger");
+        header9.setVersion("0");
+        header9.setUuid("0000");
+        GetConversationsByIdsRequest getConversationsByIdEntry = new GetConversationsByIdsRequest();
+        getConversationsByIdsRequestREST.setHeader(header9);
+        getConversationsByIdsRequestREST.setData(getConversationsByIdEntry);
+
+    }
+
+    @Test
+    public void traceRouteToLogin(){
+        Response r = router.handle(loginRequestREST);
+        assertThat(r.getData(),is(instanceOf(LoginResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToRegister(){
+        Response r = router.handle(registerRequestREST);
+        assertThat(r.getData(),is(instanceOf(RegisterResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToSmsConfirm(){
+        Response r = router.handle(smsConfirmRequestREST);
+        assertThat(r.getData(),is(instanceOf(SmsConfirmResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToContactsSync(){
+        Response r = router.handle(contactsSyncRequestREST);
+        assertThat(r.getData(),is(instanceOf(ContactsSyncResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToContactProfiles(){
+        Response r = router.handle(getContactProfilesRequestREST);
+        assertThat(r.getData(),is(instanceOf(GetContactProfilesResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteLastTimeOnline(){
+        Response r = router.handle(getLastTimeOnlineRequestREST);
+        assertThat(r.getData(),is(instanceOf(GetLastTimeOnlineResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToCreateConversation(){
+        Response r = router.handle(createConversationRequestREST);
+        assertThat(r.getData(),is(instanceOf(CreateConversationResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToDeleteConversation(){
+        Response r = router.handle(deleteConversationRequestREST);
+        assertThat(r.getData(),is(instanceOf(DeleteConversationResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteGetConversationsByIds(){
+        Response r = router.handle(getConversationsByIdsRequestREST);
+        assertThat(r.getData(),is(instanceOf(GetConversationsByIdsResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+    @Test
+    public void traceRouteToErrorHandler(){
+        Response r = router.handle(badRequestREST);
+        assertThat(r.getStatus().getCode(),is(422));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+}

--- a/softgroup/services/common/pom.xml
+++ b/softgroup/services/common/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>services</artifactId>
+        <groupId>com.softgroup</groupId>
+        <version>0.0.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>common</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>common-impl</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.softgroup</groupId>
+                <artifactId>authorization-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.softgroup</groupId>
+                <artifactId>messenger-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.softgroup</groupId>
+                <artifactId>profile-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.softgroup</groupId>
+                <artifactId>authorization-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.softgroup</groupId>
+                <artifactId>messenger-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.softgroup</groupId>
+                <artifactId>profile-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/softgroup/services/messenger/messenger-api/pom.xml
+++ b/softgroup/services/messenger/messenger-api/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>messenger</artifactId>
+        <groupId>com.softgroup</groupId>
+        <version>0.0.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>messenger-api</artifactId>
+
+</project>

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/CreateConversationRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/CreateConversationRequest.java
@@ -1,0 +1,29 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class CreateConversationRequest implements RequestData {
+    private int type;
+    private ArrayList<String> members_ids;
+
+    public int getType() {
+        return type;
+    }
+
+    public void setType(int type) {
+        this.type = type;
+    }
+
+    public ArrayList<String> getMembers_ids() {
+        return members_ids;
+    }
+
+    public void setMembers_ids(ArrayList<String> members_ids) {
+        this.members_ids = members_ids;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/CreateConversationResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/CreateConversationResponse.java
@@ -1,0 +1,19 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.Conversation;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class CreateConversationResponse implements ResponseData {
+    private Conversation conversation;
+
+    public Conversation getConversation() {
+        return conversation;
+    }
+
+    public void setConversation(Conversation conversation) {
+        this.conversation = conversation;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/DeleteConversationRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/DeleteConversationRequest.java
@@ -1,0 +1,18 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class DeleteConversationRequest implements RequestData {
+    private String conversation_id;
+
+    public String getConversation_id() {
+        return conversation_id;
+    }
+
+    public void setConversation_id(String conversation_id) {
+        this.conversation_id = conversation_id;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/DeleteConversationResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/DeleteConversationResponse.java
@@ -1,0 +1,9 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class DeleteConversationResponse implements ResponseData {
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationDetailsRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationDetailsRequest.java
@@ -1,0 +1,18 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationDetailsRequest implements RequestData {
+    private String conversation_id;
+
+    public String getConversation_id() {
+        return conversation_id;
+    }
+
+    public void setConversation_id(String conversation_id) {
+        this.conversation_id = conversation_id;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationDetailsResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationDetailsResponse.java
@@ -1,0 +1,19 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.ConversationDetails;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationDetailsResponse implements ResponseData {
+    private ConversationDetails conversation_details;
+
+    public ConversationDetails getConversation_details() {
+        return conversation_details;
+    }
+
+    public void setConversation_details(ConversationDetails conversation_details) {
+        this.conversation_details = conversation_details;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationSettingsRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationSettingsRequest.java
@@ -1,0 +1,18 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationSettingsRequest implements RequestData {
+    private String conversation_id;
+
+    public String getConversation_id() {
+        return conversation_id;
+    }
+
+    public void setConversation_id(String conversation_id) {
+        this.conversation_id = conversation_id;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationSettingsResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationSettingsResponse.java
@@ -1,0 +1,19 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.ConversationSettings;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationSettingsResponse implements ResponseData {
+    private ConversationSettings conversation_settings;
+
+    public ConversationSettings getConversation_settings() {
+        return conversation_settings;
+    }
+
+    public void setConversation_settings(ConversationSettings conversation_settings) {
+        this.conversation_settings = conversation_settings;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsByIdsRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsByIdsRequest.java
@@ -1,0 +1,20 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsByIdsRequest implements RequestData {
+    private ArrayList<String> conversations_ids;
+
+    public ArrayList<String> getConversations_ids() {
+        return conversations_ids;
+    }
+
+    public void setConversations_ids(ArrayList<String> conversations_ids) {
+        this.conversations_ids = conversations_ids;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsByIdsResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsByIdsResponse.java
@@ -1,0 +1,21 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.Conversation;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsByIdsResponse implements ResponseData {
+    private ArrayList<Conversation> conversations;
+
+    public ArrayList<Conversation> getConversations() {
+        return conversations;
+    }
+
+    public void setConversations(ArrayList<Conversation> conversations) {
+        this.conversations = conversations;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsDetailsRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsDetailsRequest.java
@@ -1,0 +1,20 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsDetailsRequest implements RequestData {
+    private ArrayList<String> conversations_ids;
+
+    public ArrayList<String> getConversations_ids() {
+        return conversations_ids;
+    }
+
+    public void setConversations_ids(ArrayList<String> conversations_ids) {
+        this.conversations_ids = conversations_ids;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsDetailsResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsDetailsResponse.java
@@ -1,0 +1,21 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.ConversationDetails;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsDetailsResponse implements ResponseData {
+    private ArrayList<ConversationDetails> conversations_details;
+
+    public ArrayList<ConversationDetails> getConversations_details() {
+        return conversations_details;
+    }
+
+    public void setConversations_details(ArrayList<ConversationDetails> conversations_details) {
+        this.conversations_details = conversations_details;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsRequest.java
@@ -1,0 +1,24 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsRequest implements RequestData {
+    /*
+        * "type:
+        0-индивидуальный
+        1-групповой
+        если не указан — тогда все"
+        */
+    private int type;
+
+    public int getType() {
+        return type;
+    }
+
+    public void setType(int type) {
+        this.type = type;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsResponse.java
@@ -1,0 +1,22 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.Conversation;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsResponse implements ResponseData {
+
+    private ArrayList<Conversation> conversations;
+
+    public ArrayList<Conversation> getConversations() {
+        return conversations;
+    }
+
+    public void setConversations(ArrayList<Conversation> conversations) {
+        this.conversations = conversations;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsSettingsRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsSettingsRequest.java
@@ -1,0 +1,20 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsSettingsRequest implements RequestData {
+    private ArrayList<String> conversations_ids;
+
+    public ArrayList<String> getConversations_ids() {
+        return conversations_ids;
+    }
+
+    public void setConversations_ids(ArrayList<String> conversations_ids) {
+        this.conversations_ids = conversations_ids;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsSettingsResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetConversationsSettingsResponse.java
@@ -1,0 +1,21 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.ConversationSettings;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsSettingsResponse implements ResponseData {
+    private ArrayList<ConversationSettings> conversations_settings;
+
+    public ArrayList<ConversationSettings> getConversations_settings() {
+        return conversations_settings;
+    }
+
+    public void setConversations_settings(ArrayList<ConversationSettings> conversations_settings) {
+        this.conversations_settings = conversations_settings;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetMessagesRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetMessagesRequest.java
@@ -1,0 +1,28 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+import com.softgroup.common.protocol.entry.CursorRequest;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetMessagesRequest implements RequestData {
+    private String conversations_id;
+    private CursorRequest cursor;
+
+    public String getConversations_id() {
+        return conversations_id;
+    }
+
+    public void setConversations_id(String conversations_id) {
+        this.conversations_id = conversations_id;
+    }
+
+    public CursorRequest getCursor() {
+        return cursor;
+    }
+
+    public void setCursor(CursorRequest cursor) {
+        this.cursor = cursor;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetMessagesResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/GetMessagesResponse.java
@@ -1,0 +1,40 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.CursorResponse;
+import com.softgroup.common.protocol.entry.Message;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetMessagesResponse implements ResponseData {
+    private ArrayList<Message> messages;
+    private int total_unread;
+    private CursorResponse cursor;
+
+    public ArrayList<Message> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(ArrayList<Message> messages) {
+        this.messages = messages;
+    }
+
+    public int getTotal_unread() {
+        return total_unread;
+    }
+
+    public void setTotal_unread(int total_unread) {
+        this.total_unread = total_unread;
+    }
+
+    public CursorResponse getCursor() {
+        return cursor;
+    }
+
+    public void setCursor(CursorResponse cursor) {
+        this.cursor = cursor;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/IsTypingInChatRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/IsTypingInChatRequest.java
@@ -1,0 +1,18 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class IsTypingInChatRequest implements RequestData {
+    private String conversation_id;
+
+    public String getConversation_id() {
+        return conversation_id;
+    }
+
+    public void setConversation_id(String conversation_id) {
+        this.conversation_id = conversation_id;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/IsTypingInChatResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/IsTypingInChatResponse.java
@@ -1,0 +1,9 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class IsTypingInChatResponse implements ResponseData {
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/MessagesReadConfirmationRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/MessagesReadConfirmationRequest.java
@@ -1,0 +1,29 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class MessagesReadConfirmationRequest implements RequestData {
+    private String conversation_id;
+    private ArrayList<String> messages_ids;
+
+    public String getConversation_id() {
+        return conversation_id;
+    }
+
+    public void setConversation_id(String conversation_id) {
+        this.conversation_id = conversation_id;
+    }
+
+    public ArrayList<String> getMessages_ids() {
+        return messages_ids;
+    }
+
+    public void setMessages_ids(ArrayList<String> messages_ids) {
+        this.messages_ids = messages_ids;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/MessagesReadConfirmationResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/MessagesReadConfirmationResponse.java
@@ -1,0 +1,9 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class MessagesReadConfirmationResponse implements ResponseData {
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/SendMessageRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/SendMessageRequest.java
@@ -1,0 +1,21 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+import com.softgroup.common.protocol.entry.DTO.MessageRequestDTO;
+import com.softgroup.common.protocol.entry.Message;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class SendMessageRequest implements RequestData {
+
+    private MessageRequestDTO message;
+
+    public MessageRequestDTO getMessage() {
+        return message;
+    }
+
+    public void setMessage(MessageRequestDTO message) {
+        this.message = message;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/SendMessageResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/SendMessageResponse.java
@@ -1,0 +1,19 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.Message;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class SendMessageResponse implements ResponseData {
+    private Message message;
+
+    public Message getMessage() {
+        return message;
+    }
+
+    public void setMessage(Message message) {
+        this.message = message;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/UpdateConversationSettingsRequest.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/UpdateConversationSettingsRequest.java
@@ -1,0 +1,19 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+import com.softgroup.common.protocol.entry.ConversationSettings;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class UpdateConversationSettingsRequest implements RequestData {
+    private ConversationSettings conversation_settings;
+
+    public ConversationSettings getConversation_settings() {
+        return conversation_settings;
+    }
+
+    public void setConversation_settings(ConversationSettings conversation_settings) {
+        this.conversation_settings = conversation_settings;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/UpdateConversationSettingsResponse.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/message/UpdateConversationSettingsResponse.java
@@ -1,0 +1,19 @@
+package com.softgroup.messenger.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.ConversationSettings;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class UpdateConversationSettingsResponse implements ResponseData {
+    private ConversationSettings conversation_settings;
+
+    public ConversationSettings getConversation_settings() {
+        return conversation_settings;
+    }
+
+    public void setConversation_settings(ConversationSettings conversation_settings) {
+        this.conversation_settings = conversation_settings;
+    }
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/router/MessengerRequestHandler.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/router/MessengerRequestHandler.java
@@ -1,0 +1,9 @@
+package com.softgroup.messenger.api.router;
+
+import com.softgroup.common.router.api.RequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public interface MessengerRequestHandler extends RequestHandler {
+}

--- a/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/router/MessengerRouterHandler.java
+++ b/softgroup/services/messenger/messenger-api/src/main/java/com/softgroup/messenger/api/router/MessengerRouterHandler.java
@@ -1,0 +1,10 @@
+package com.softgroup.messenger.api.router;
+
+import com.softgroup.common.router.api.CommonRouterHandler;
+import com.softgroup.common.router.api.RouterHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public interface MessengerRouterHandler extends RouterHandler, CommonRouterHandler {
+}

--- a/softgroup/services/messenger/messenger-impl/pom.xml
+++ b/softgroup/services/messenger/messenger-impl/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>messenger</artifactId>
+        <groupId>com.softgroup</groupId>
+        <version>0.0.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>messenger-impl</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>messenger-api</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/CreateConversationRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/CreateConversationRequestHandler.java
@@ -1,0 +1,26 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.CreateConversationRequest;
+import com.softgroup.messenger.api.message.CreateConversationResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class CreateConversationRequestHandler extends AbstractRequestHandler<CreateConversationRequest,CreateConversationResponse> implements MessengerRequestHandler {
+
+    public String getName(){
+        return "create_conversation";
+    }
+
+    @Override
+    public Response<CreateConversationResponse> handle(Request<?> msg) {
+        Response<CreateConversationResponse> response = new Response<CreateConversationResponse>();
+        response.setData(new CreateConversationResponse());
+        return response;
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/DeleteConversationRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/DeleteConversationRequestHandler.java
@@ -1,0 +1,27 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.CreateConversationResponse;
+import com.softgroup.messenger.api.message.DeleteConversationRequest;
+import com.softgroup.messenger.api.message.DeleteConversationResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class DeleteConversationRequestHandler extends AbstractRequestHandler<DeleteConversationRequest,DeleteConversationResponse> implements MessengerRequestHandler {
+
+    public String getName(){
+        return "delete_conversation";
+    }
+
+    @Override
+    public Response<DeleteConversationResponse> handle(Request<?> msg) {
+        Response<DeleteConversationResponse> response = new Response<DeleteConversationResponse>();
+        response.setData(new DeleteConversationResponse());
+        return response;
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationDetailsRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationDetailsRequestHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.GetConversationDetailsRequest;
+import com.softgroup.messenger.api.message.GetConversationDetailsResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationDetailsRequestHandler extends AbstractRequestHandler<GetConversationDetailsRequest,GetConversationDetailsResponse>  implements MessengerRequestHandler {
+
+    public String getName(){
+        return "get_conversation_details";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationSettingsRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationSettingsRequestHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.GetConversationSettingsRequest;
+import com.softgroup.messenger.api.message.GetConversationSettingsResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationSettingsRequestHandler extends AbstractRequestHandler<GetConversationSettingsRequest,GetConversationSettingsResponse> implements MessengerRequestHandler {
+
+    public String getName(){
+        return "get_conversation_settings";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationsByIdsRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationsByIdsRequestHandler.java
@@ -1,0 +1,27 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.DeleteConversationResponse;
+import com.softgroup.messenger.api.message.GetConversationsByIdsRequest;
+import com.softgroup.messenger.api.message.GetConversationsByIdsResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsByIdsRequestHandler extends AbstractRequestHandler<GetConversationsByIdsRequest,GetConversationsByIdsResponse> implements MessengerRequestHandler {
+
+    public String getName(){
+        return "get_conversations_by_ids";
+    }
+
+    @Override
+    public Response<GetConversationsByIdsResponse> handle(Request<?> msg) {
+        Response<GetConversationsByIdsResponse> response = new Response<GetConversationsByIdsResponse>();
+        response.setData(new GetConversationsByIdsResponse());
+        return response;
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationsDetailsRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationsDetailsRequestHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.GetConversationsDetailsRequest;
+import com.softgroup.messenger.api.message.GetConversationsDetailsResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsDetailsRequestHandler extends AbstractRequestHandler<GetConversationsDetailsRequest,GetConversationsDetailsResponse>implements MessengerRequestHandler {
+
+    public String getName(){
+        return "get_conversations_details";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationsRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationsRequestHandler.java
@@ -1,0 +1,18 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+
+import com.softgroup.messenger.api.message.GetConversationsRequest;
+import com.softgroup.messenger.api.message.GetConversationsResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsRequestHandler extends AbstractRequestHandler<GetConversationsRequest,GetConversationsResponse> implements MessengerRequestHandler {
+
+    public String getName(){
+        return "get_conversations";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationsSettingsRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetConversationsSettingsRequestHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.GetConversationsSettingsRequest;
+import com.softgroup.messenger.api.message.GetConversationsSettingsResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetConversationsSettingsRequestHandler extends AbstractRequestHandler<GetConversationsSettingsRequest,GetConversationsSettingsResponse>implements MessengerRequestHandler {
+
+    public String getName(){
+        return "get_conversations_settings";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetMessagesRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/GetMessagesRequestHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.GetMessagesRequest;
+import com.softgroup.messenger.api.message.GetMessagesResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetMessagesRequestHandler extends AbstractRequestHandler<GetMessagesRequest,GetMessagesResponse> implements MessengerRequestHandler {
+
+    public String getName(){
+        return "get_messages";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/IsTypingInChatRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/IsTypingInChatRequestHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.IsTypingInChatRequest;
+import com.softgroup.messenger.api.message.IsTypingInChatResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class IsTypingInChatRequestHandler extends AbstractRequestHandler<IsTypingInChatRequest,IsTypingInChatResponse> implements MessengerRequestHandler {
+
+    public String getName(){
+        return " is_typing_in_chat";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/MessagesReadConfirmationRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/MessagesReadConfirmationRequestHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.MessagesReadConfirmationRequest;
+import com.softgroup.messenger.api.message.MessagesReadConfirmationResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class MessagesReadConfirmationRequestHandler extends AbstractRequestHandler<MessagesReadConfirmationRequest,MessagesReadConfirmationResponse> implements MessengerRequestHandler {
+
+    public String getName(){
+        return "messages_read_confirmation";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/SendMessageRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/SendMessageRequestHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.SendMessageRequest;
+import com.softgroup.messenger.api.message.SendMessageResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class SendMessageRequestHandler extends AbstractRequestHandler<SendMessageRequest,SendMessageResponse> implements MessengerRequestHandler {
+
+    public String getName(){
+        return "send_message";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/UpdateConversationSettingsRequestHandler.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/handler/UpdateConversationSettingsRequestHandler.java
@@ -1,0 +1,17 @@
+package com.softgroup.messenger.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.messenger.api.message.UpdateConversationSettingsRequest;
+import com.softgroup.messenger.api.message.UpdateConversationSettingsResponse;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class UpdateConversationSettingsRequestHandler extends AbstractRequestHandler<UpdateConversationSettingsRequest,UpdateConversationSettingsResponse> implements MessengerRequestHandler {
+
+    public String getName(){
+        return "update_conversation_settings";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/router/MessengerRouter.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/router/MessengerRouter.java
@@ -1,0 +1,22 @@
+package com.softgroup.messenger.impl.router;
+
+import com.softgroup.common.router.api.AbstractCommandRouterHandler;
+
+import com.softgroup.common.router.api.CommandTypeRouter;
+import com.softgroup.common.router.api.CommonRouterHandler;
+import com.softgroup.messenger.api.router.MessengerRequestHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+
+@Component
+public class MessengerRouter extends AbstractCommandRouterHandler<MessengerRequestHandler> implements CommandTypeRouter {
+
+    @Override
+    public String getName(){
+        return "messenger";
+    }
+
+}

--- a/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/router/MessengerRouterBean.java
+++ b/softgroup/services/messenger/messenger-impl/src/main/java/com/softgroup/messenger/impl/router/MessengerRouterBean.java
@@ -1,0 +1,18 @@
+package com.softgroup.messenger.impl.router;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Created by user on 27.02.2017.
+ */
+
+@Configuration
+public class MessengerRouterBean {
+
+    @Bean
+    public MessengerRouter profileRouter(){
+        return new MessengerRouter();
+    }
+}
+

--- a/softgroup/services/messenger/messenger-impl/src/test/java/com/softgroup/messenger/impl/router/MessengerRouterTest.java
+++ b/softgroup/services/messenger/messenger-impl/src/test/java/com/softgroup/messenger/impl/router/MessengerRouterTest.java
@@ -1,0 +1,115 @@
+package com.softgroup.messenger.impl.router;
+
+import com.softgroup.common.protocol.ActionHeader;
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.messenger.api.message.*;
+import com.softgroup.messenger.impl.handler.CreateConversationRequestHandler;
+import com.softgroup.messenger.impl.handler.DeleteConversationRequestHandler;
+import com.softgroup.messenger.impl.handler.GetConversationsByIdsRequestHandler;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by user on 27.02.2017.
+ */
+@DirtiesContext
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {MessengerRouterBean.class, CreateConversationRequestHandler.class,
+        DeleteConversationRequestHandler.class,
+        GetConversationsByIdsRequestHandler.class})
+public class MessengerRouterTest {
+
+    @Autowired
+    MessengerRouter router;
+
+    @Test
+    public void isRouterExist(){
+        assertThat(router, CoreMatchers.notNullValue());
+    }
+
+    private Request<CreateConversationRequest> createConversationRequestREST;
+    private Request<DeleteConversationRequest> deleteConversationRequestREST;
+    private Request<GetConversationsByIdsRequest> getConversationsByIdsRequestREST;
+    private Request badRequestREST;
+
+    @Before
+    public void createRequests(){
+        createConversationRequestREST = new Request<CreateConversationRequest>();
+        ActionHeader header = new ActionHeader();
+        header.setCommand("create_conversation");
+        header.setType("messenger");
+        header.setVersion("0");
+        header.setUuid("0000");
+        CreateConversationRequest createConversationEntry = new CreateConversationRequest();
+        createConversationRequestREST.setHeader(header);
+        createConversationRequestREST.setData(createConversationEntry);
+
+        deleteConversationRequestREST = new Request<DeleteConversationRequest>();
+        ActionHeader header1 = new ActionHeader();
+        header1.setCommand("delete_conversation");
+        header1.setType("messenger");
+        header1.setVersion("0");
+        header1.setUuid("0000");
+        DeleteConversationRequest deleteConversationEntry = new DeleteConversationRequest();
+        deleteConversationRequestREST.setHeader(header1);
+        deleteConversationRequestREST.setData(deleteConversationEntry);
+
+        getConversationsByIdsRequestREST = new Request<GetConversationsByIdsRequest>();
+        ActionHeader header2 = new ActionHeader();
+        header2.setCommand("get_conversations_by_ids");
+        header2.setType("messenger");
+        header2.setVersion("0");
+        header2.setUuid("0000");
+        GetConversationsByIdsRequest getConversationsByIdEntry = new GetConversationsByIdsRequest();
+        getConversationsByIdsRequestREST.setHeader(header2);
+        getConversationsByIdsRequestREST.setData(getConversationsByIdEntry);
+
+        badRequestREST = new Request();
+        ActionHeader header3 = new ActionHeader();
+        header3.setCommand("sms_conform");
+        header3.setType("auth");
+        header3.setVersion("0");
+        header3.setUuid("0000");
+        badRequestREST.setHeader(header3);
+
+    }
+
+    @Test
+    public void traceRouteToCreateConversation(){
+        Response r = router.handle(createConversationRequestREST);
+        assertThat(r.getData(),is(instanceOf(CreateConversationResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToDeleteConversation(){
+        Response r = router.handle(deleteConversationRequestREST);
+        assertThat(r.getData(),is(instanceOf(DeleteConversationResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteGetConversationsByIds(){
+        Response r = router.handle(getConversationsByIdsRequestREST);
+        assertThat(r.getData(),is(instanceOf(GetConversationsByIdsResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToErrorHandler(){
+        Response r = router.handle(badRequestREST);
+        assertThat(r.getStatus().getCode(),is(422));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+}

--- a/softgroup/services/messenger/pom.xml
+++ b/softgroup/services/messenger/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>services</artifactId>
+        <groupId>com.softgroup</groupId>
+        <version>0.0.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>messenger</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>messenger-api</module>
+        <module>messenger-impl</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.softgroup</groupId>
+                <artifactId>messenger-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/softgroup/services/pom.xml
+++ b/softgroup/services/pom.xml
@@ -1,59 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.softgroup</groupId>
-		<artifactId>softgroup</artifactId>
-		<version>0.0.1</version>
-	</parent>
-	<artifactId>services</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.softgroup</groupId>
+        <artifactId>softgroup</artifactId>
+        <version>0.0.1</version>
+    </parent>
+    <artifactId>services</artifactId>
 
-	<packaging>pom</packaging>
+    <packaging>pom</packaging>
 
-	<modules>
+    <modules>
+        <module>authorization</module>
+        <module>profile</module>
+        <module>messenger</module>
+    </modules>
 
-		<module>authorization</module>
-	</modules>
+    <properties>
+        <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
-	<properties>
-		<endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+    <dependencyManagement>
+        <dependencies>
 
-	<dependencyManagement>
-		<dependencies>
+            <dependency>
+                <groupId>com.softgroup</groupId>
+                <artifactId>common-protocol</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
-			<dependency>
-				<groupId>com.softgroup</groupId>
-				<artifactId>common-protocol</artifactId>
-				<version>${project.version}</version>
-			</dependency>
+            <dependency>
+                <groupId>com.softgroup</groupId>
+                <artifactId>common-router</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
-			<dependency>
-				<groupId>com.softgroup</groupId>
-				<artifactId>common-router</artifactId>
-				<version>${project.version}</version>
-			</dependency>
+        </dependencies>
+    </dependencyManagement>
 
-		</dependencies>
-	</dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>common-datamapper</artifactId>
+        </dependency>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.softgroup</groupId>
-			<artifactId>common-datamapper</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>common-protocol</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>com.softgroup</groupId>
-			<artifactId>common-protocol</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.softgroup</groupId>
-			<artifactId>common-router</artifactId>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>common-router</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/softgroup/services/profile/pom.xml
+++ b/softgroup/services/profile/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>services</artifactId>
+        <groupId>com.softgroup</groupId>
+        <version>0.0.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>profile</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>profile-api</module>
+        <module>profile-impl</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.softgroup</groupId>
+                <artifactId>profile-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/softgroup/services/profile/profile-api/pom.xml
+++ b/softgroup/services/profile/profile-api/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>profile</artifactId>
+        <groupId>com.softgroup</groupId>
+        <version>0.0.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>profile-api</artifactId>
+
+
+
+</project>

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/ContactsSyncRequest.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/ContactsSyncRequest.java
@@ -1,0 +1,21 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+import com.softgroup.common.protocol.entry.Contact;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ContactsSyncRequest implements RequestData {
+    private ArrayList<Contact> added_contct;
+
+    public ArrayList<Contact> getAdded_contct() {
+        return added_contct;
+    }
+
+    public void setAdded_contct(ArrayList<Contact> added_contct) {
+        this.added_contct = added_contct;
+    }
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/ContactsSyncResponse.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/ContactsSyncResponse.java
@@ -1,0 +1,9 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ContactsSyncResponse  implements ResponseData {
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetContactProfilesRequest.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetContactProfilesRequest.java
@@ -1,0 +1,11 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetContactProfilesRequest implements RequestData {
+
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetContactProfilesResponse.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetContactProfilesResponse.java
@@ -1,0 +1,22 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.Profile;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetContactProfilesResponse implements ResponseData {
+
+    private ArrayList<Profile> profiles;
+
+    public ArrayList<Profile> getProfiles() {
+        return profiles;
+    }
+
+    public void setProfiles(ArrayList<Profile> profiles) {
+        this.profiles = profiles;
+    }
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetLastTimeOnlineRequest.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetLastTimeOnlineRequest.java
@@ -1,0 +1,21 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetLastTimeOnlineRequest implements RequestData {
+
+    private ArrayList<String> profiles;
+
+    public ArrayList<String> getProfiles() {
+        return profiles;
+    }
+
+    public void setProfiles(ArrayList<String> profiles) {
+        this.profiles = profiles;
+    }
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetLastTimeOnlineResponse.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetLastTimeOnlineResponse.java
@@ -1,0 +1,14 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.ProfileStatus;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetLastTimeOnlineResponse  implements ResponseData {
+
+    private ArrayList<ProfileStatus> profiles;
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetMyProfileRequest.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetMyProfileRequest.java
@@ -1,0 +1,9 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetMyProfileRequest implements RequestData {
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetMyProfileResponse.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetMyProfileResponse.java
@@ -1,0 +1,21 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.Profile;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetMyProfileResponse implements ResponseData {
+    private ArrayList<Profile> profile;
+
+    public ArrayList<Profile> getProfile() {
+        return profile;
+    }
+
+    public void setProfile(ArrayList<Profile> profile) {
+        this.profile = profile;
+    }
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetOtherProfilesRequest.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetOtherProfilesRequest.java
@@ -1,0 +1,21 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetOtherProfilesRequest implements RequestData {
+
+    private ArrayList<String> user_id;
+
+    public ArrayList<String> getUser_id() {
+        return user_id;
+    }
+
+    public void setUser_id(ArrayList<String> user_id) {
+        this.user_id = user_id;
+    }
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetOtherProfilesResponse.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetOtherProfilesResponse.java
@@ -1,0 +1,22 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.Profile;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetOtherProfilesResponse implements ResponseData {
+
+    private ArrayList<Profile> profiles;
+
+    public ArrayList<Profile> getProfiles() {
+        return profiles;
+    }
+
+    public void setProfiles(ArrayList<Profile> profiles) {
+        this.profiles = profiles;
+    }
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetProfileSettingsRequest.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetProfileSettingsRequest.java
@@ -1,0 +1,9 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetProfileSettingsRequest implements RequestData {
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetProfileSettingsResponse.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/GetProfileSettingsResponse.java
@@ -1,0 +1,20 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+import com.softgroup.common.protocol.entry.ProfileSettings;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetProfileSettingsResponse implements ResponseData {
+
+    private ProfileSettings settings;
+
+    public ProfileSettings getSettings() {
+        return settings;
+    }
+
+    public void setSettings(ProfileSettings settings) {
+        this.settings = settings;
+    }
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/SetMyProfileRequest.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/SetMyProfileRequest.java
@@ -1,0 +1,21 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+import com.softgroup.common.protocol.entry.Profile;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class SetMyProfileRequest implements RequestData {
+    private Profile profile;
+
+    public Profile getProfile() {
+        return profile;
+    }
+
+    public void setProfile(Profile profile) {
+        this.profile = profile;
+    }
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/SetMyProfileResponse.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/SetMyProfileResponse.java
@@ -1,0 +1,9 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class SetMyProfileResponse implements ResponseData {
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/SetProfileSettingsRequest.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/SetProfileSettingsRequest.java
@@ -1,0 +1,20 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.RequestData;
+import com.softgroup.common.protocol.entry.ProfileSettings;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class SetProfileSettingsRequest implements RequestData {
+
+    private ProfileSettings settings;
+
+    public ProfileSettings getSettings() {
+        return settings;
+    }
+
+    public void setSettings(ProfileSettings settings) {
+        this.settings = settings;
+    }
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/SetProfileSettingsResponse.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/message/SetProfileSettingsResponse.java
@@ -1,0 +1,12 @@
+package com.softgroup.profile.api.message;
+
+import com.softgroup.common.protocol.ResponseData;
+
+import java.util.ArrayList;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class SetProfileSettingsResponse implements ResponseData {
+
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/router/ProfileRequestHandler.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/router/ProfileRequestHandler.java
@@ -1,0 +1,9 @@
+package com.softgroup.profile.api.router;
+
+import com.softgroup.common.router.api.RequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public interface ProfileRequestHandler extends RequestHandler {
+}

--- a/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/router/ProfileRouterHandler.java
+++ b/softgroup/services/profile/profile-api/src/main/java/com/softgroup/profile/api/router/ProfileRouterHandler.java
@@ -1,0 +1,10 @@
+package com.softgroup.profile.api.router;
+
+import com.softgroup.common.router.api.CommonRouterHandler;
+import com.softgroup.common.router.api.RouterHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public interface ProfileRouterHandler extends RouterHandler, CommonRouterHandler {
+}

--- a/softgroup/services/profile/profile-impl/pom.xml
+++ b/softgroup/services/profile/profile-impl/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>profile</artifactId>
+        <groupId>com.softgroup</groupId>
+        <version>0.0.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>profile-impl</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.softgroup</groupId>
+            <artifactId>profile-api</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/ContactsSyncRequestHandler.java
+++ b/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/ContactsSyncRequestHandler.java
@@ -1,0 +1,24 @@
+package com.softgroup.profile.impl.handler;
+
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.profile.api.message.ContactsSyncRequest;
+import com.softgroup.profile.api.message.ContactsSyncResponse;
+import com.softgroup.profile.api.router.ProfileRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class ContactsSyncRequestHandler extends AbstractRequestHandler<ContactsSyncRequest,ContactsSyncResponse> implements ProfileRequestHandler{
+    public String getName(){
+        return "contacts_sync";
+    }
+
+    @Override
+    public Response<ContactsSyncResponse> handle(Request<?> msg) {
+        Response<ContactsSyncResponse> response = new Response<ContactsSyncResponse>();
+        response.setData(new ContactsSyncResponse());
+        return response;
+    }
+}

--- a/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/GetContactProfilesRequestHandler.java
+++ b/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/GetContactProfilesRequestHandler.java
@@ -1,0 +1,24 @@
+package com.softgroup.profile.impl.handler;
+
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.profile.api.message.GetContactProfilesRequest;
+import com.softgroup.profile.api.message.GetContactProfilesResponse;
+import com.softgroup.profile.api.router.ProfileRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetContactProfilesRequestHandler extends AbstractRequestHandler<GetContactProfilesRequest,GetContactProfilesResponse>  implements ProfileRequestHandler {
+    public String getName(){
+        return "get_contact_profiles";
+    }
+
+    @Override
+    public Response<GetContactProfilesResponse> handle(Request<?> msg) {
+        Response<GetContactProfilesResponse> response = new Response<GetContactProfilesResponse>();
+        response.setData(new GetContactProfilesResponse());
+        return response;
+    }
+}

--- a/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/GetLastTimeOnlineRequestHandler.java
+++ b/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/GetLastTimeOnlineRequestHandler.java
@@ -1,0 +1,24 @@
+package com.softgroup.profile.impl.handler;
+
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.profile.api.message.GetLastTimeOnlineRequest;
+import com.softgroup.profile.api.message.GetLastTimeOnlineResponse;
+import com.softgroup.profile.api.router.ProfileRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetLastTimeOnlineRequestHandler extends AbstractRequestHandler<GetLastTimeOnlineRequest,GetLastTimeOnlineResponse>  implements ProfileRequestHandler {
+    public String getName(){
+        return "get_last_time_online";
+    }
+
+    @Override
+    public Response<GetLastTimeOnlineResponse> handle(Request<?> msg) {
+        Response<GetLastTimeOnlineResponse> response = new Response<GetLastTimeOnlineResponse>();
+        response.setData(new GetLastTimeOnlineResponse());
+        return response;
+    }
+}

--- a/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/GetMyProfileRequestHandler.java
+++ b/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/GetMyProfileRequestHandler.java
@@ -1,0 +1,15 @@
+package com.softgroup.profile.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.profile.api.message.GetMyProfileRequest;
+import com.softgroup.profile.api.message.GetMyProfileResponse;
+import com.softgroup.profile.api.router.ProfileRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetMyProfileRequestHandler extends AbstractRequestHandler<GetMyProfileRequest,GetMyProfileResponse>  implements ProfileRequestHandler {
+    public String getName(){
+        return "get_my_profile";
+    }
+}

--- a/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/GetOtherProfilesRequestHandler.java
+++ b/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/GetOtherProfilesRequestHandler.java
@@ -1,0 +1,15 @@
+package com.softgroup.profile.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.profile.api.message.GetMyProfileRequest;
+import com.softgroup.profile.api.message.GetMyProfileResponse;
+import com.softgroup.profile.api.router.ProfileRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetOtherProfilesRequestHandler extends AbstractRequestHandler<GetMyProfileRequest,GetMyProfileResponse>  implements ProfileRequestHandler {
+    public String getName(){
+        return "get_other_profiles";
+    }
+}

--- a/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/GetProfileSettingsRequestHandler.java
+++ b/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/GetProfileSettingsRequestHandler.java
@@ -1,0 +1,15 @@
+package com.softgroup.profile.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.profile.api.message.GetProfileSettingsRequest;
+import com.softgroup.profile.api.message.GetProfileSettingsResponse;
+import com.softgroup.profile.api.router.ProfileRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class GetProfileSettingsRequestHandler extends AbstractRequestHandler<GetProfileSettingsRequest,GetProfileSettingsResponse>  implements ProfileRequestHandler {
+    public String getName(){
+        return " get_profile_settings";
+    }
+}

--- a/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/SetMyProfileRequestHandler.java
+++ b/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/SetMyProfileRequestHandler.java
@@ -1,0 +1,15 @@
+package com.softgroup.profile.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.profile.api.message.SetMyProfileRequest;
+import com.softgroup.profile.api.message.SetMyProfileResponse;
+import com.softgroup.profile.api.router.ProfileRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class SetMyProfileRequestHandler extends AbstractRequestHandler<SetMyProfileRequest,SetMyProfileResponse>  implements ProfileRequestHandler {
+    public String getName(){
+        return "set_my_profile";
+    }
+}

--- a/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/SetProfileSettingsRequestHandler.java
+++ b/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/handler/SetProfileSettingsRequestHandler.java
@@ -1,0 +1,15 @@
+package com.softgroup.profile.impl.handler;
+
+import com.softgroup.common.router.api.AbstractRequestHandler;
+import com.softgroup.profile.api.message.SetMyProfileRequest;
+import com.softgroup.profile.api.message.SetMyProfileResponse;
+import com.softgroup.profile.api.router.ProfileRequestHandler;
+
+/**
+ * Created by user on 26.02.2017.
+ */
+public class SetProfileSettingsRequestHandler extends AbstractRequestHandler<SetMyProfileRequest,SetMyProfileResponse>  implements ProfileRequestHandler {
+    public String getName(){
+        return "set_profile_settings";
+    }
+}

--- a/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/router/ProfileRouter.java
+++ b/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/router/ProfileRouter.java
@@ -1,0 +1,21 @@
+package com.softgroup.profile.impl.router;
+import com.softgroup.common.router.api.AbstractCommandRouterHandler;
+
+import com.softgroup.common.router.api.CommandTypeRouter;
+import com.softgroup.common.router.api.CommonRouterHandler;
+import com.softgroup.profile.api.router.ProfileRequestHandler;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * Created by user on 26.02.2017.
+ */
+@Component
+public class ProfileRouter extends AbstractCommandRouterHandler<ProfileRequestHandler> implements CommandTypeRouter {
+
+    @Override
+    public String getName(){
+        return "profile";
+    }
+
+}

--- a/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/router/ProfileRouterBean.java
+++ b/softgroup/services/profile/profile-impl/src/main/java/com/softgroup/profile/impl/router/ProfileRouterBean.java
@@ -1,0 +1,16 @@
+package com.softgroup.profile.impl.router;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Created by maxim on 27.02.17.
+ */
+@Configuration
+public class ProfileRouterBean {
+
+    @Bean
+    public ProfileRouter profileRouter(){
+        return new ProfileRouter();
+    }
+}

--- a/softgroup/services/profile/profile-impl/src/test/java/com/softgroup/profile/impl/router/ProfileRouterTest.java
+++ b/softgroup/services/profile/profile-impl/src/test/java/com/softgroup/profile/impl/router/ProfileRouterTest.java
@@ -1,0 +1,116 @@
+package com.softgroup.profile.impl.router;
+
+import com.softgroup.common.protocol.ActionHeader;
+import com.softgroup.common.protocol.Request;
+import com.softgroup.common.protocol.Response;
+import com.softgroup.profile.api.message.*;
+import com.softgroup.profile.impl.handler.ContactsSyncRequestHandler;
+import com.softgroup.profile.impl.handler.GetContactProfilesRequestHandler;
+import com.softgroup.profile.impl.handler.GetLastTimeOnlineRequestHandler;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by maxim on 27.02.17.
+ */
+@DirtiesContext
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {ProfileRouterBean.class, ContactsSyncRequestHandler.class,
+        GetContactProfilesRequestHandler.class,
+        GetLastTimeOnlineRequestHandler.class})
+
+public class ProfileRouterTest {
+
+    @Autowired
+    ProfileRouter router;
+
+    @Test
+    public void isRouterExist(){
+        assertThat(router, CoreMatchers.notNullValue());
+    }
+
+    private Request<ContactsSyncRequest> contactsSyncRequestREST;
+    private Request<GetContactProfilesRequest> getContactProfilesRequestREST;
+    private Request<GetLastTimeOnlineRequest> getLastTimeOnlineRequestREST;
+    private Request badRequestREST;
+
+    @Before
+    public void createRequests(){
+        contactsSyncRequestREST = new Request<ContactsSyncRequest>();
+        ActionHeader header = new ActionHeader();
+        header.setCommand("contacts_sync");
+        header.setType("profile");
+        header.setVersion("0");
+        header.setUuid("0000");
+        ContactsSyncRequest contactsSyncEntry = new ContactsSyncRequest();
+        contactsSyncRequestREST.setHeader(header);
+        contactsSyncRequestREST.setData(contactsSyncEntry);
+
+        getContactProfilesRequestREST = new Request<GetContactProfilesRequest>();
+        ActionHeader header1 = new ActionHeader();
+        header1.setCommand("get_contact_profiles");
+        header1.setType("profile");
+        header1.setVersion("0");
+        header1.setUuid("0000");
+        GetContactProfilesRequest getContactProfilesEntry = new GetContactProfilesRequest();
+        getContactProfilesRequestREST.setHeader(header1);
+        getContactProfilesRequestREST.setData(getContactProfilesEntry);
+
+        getLastTimeOnlineRequestREST = new Request<GetLastTimeOnlineRequest>();
+        ActionHeader header2 = new ActionHeader();
+        header2.setCommand("get_last_time_online");
+        header2.setType("profile");
+        header2.setVersion("0");
+        header2.setUuid("0000");
+        GetLastTimeOnlineRequest lastTimeoOnLineEntry = new GetLastTimeOnlineRequest();
+        getLastTimeOnlineRequestREST.setHeader(header2);
+        getLastTimeOnlineRequestREST.setData(lastTimeoOnLineEntry);
+
+        badRequestREST = new Request();
+        ActionHeader header3 = new ActionHeader();
+        header3.setCommand("sms_conform");
+        header3.setType("auth");
+        header3.setVersion("0");
+        header3.setUuid("0000");
+        badRequestREST.setHeader(header3);
+
+    }
+
+    @Test
+    public void traceRouteToContactsSync(){
+        Response r = router.handle(contactsSyncRequestREST);
+        assertThat(r.getData(),is(instanceOf(ContactsSyncResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToContactProfiles(){
+        Response r = router.handle(getContactProfilesRequestREST);
+        assertThat(r.getData(),is(instanceOf(GetContactProfilesResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteLastTimeOnline(){
+        Response r = router.handle(getLastTimeOnlineRequestREST);
+        assertThat(r.getData(),is(instanceOf(GetLastTimeOnlineResponse.class)));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+
+    @Test
+    public void traceRouteToErrorHandler(){
+        Response r = router.handle(badRequestREST);
+        assertThat(r.getStatus().getCode(),is(422));
+        assertThat(r,is(instanceOf(Response.class)));
+    }
+}


### PR DESCRIPTION
Разделил абстрактный класс AbstractRouterHandler.java на два абстрактных AbstractCommandRouterHandler.java и AbstractTypeRouterHandler.java.
От них унаследовались роутеры авторизации (AuthorizationRouter.java), сообщений, профилей и главный роутер по типу(CommonTypeRouter).
В некоторых обработчиках добавил тестовую заглушку для тестирования 
`    public Response<LoginResponse> handle(Request<?> msg) {
        Response<LoginResponse> response = new Response<LoginResponse>();
        response.setData(new LoginResponse());
        return response;
    }`

Ну и тут куча нужных классов, которые отвечают за наполнение request response правильными объектами.
Написал тесты для Роутеров по комманде, По типу пока не получилось.
Фабрику пока не пилил, застопорился на тесте роутера по типу потратил много времени на него.
В планах добавить Handler при возникновении ошибки при роутинге.